### PR TITLE
Migrate to cpal from rodio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,12 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
-name = "byteorder"
-version = "1.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-
-[[package]]
 name = "cc"
 version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,12 +128,6 @@ dependencies = [
  "libc",
  "libloading",
 ]
-
-[[package]]
-name = "claxon"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86c952727a495bda7abaf09bafdee1a939194dd793d9a8e26281df55ac43b00"
 
 [[package]]
 name = "core-foundation"
@@ -224,6 +212,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
+dependencies = [
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,12 +294,6 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "hound"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a164bb2ceaeff4f42542bdb847c41517c78a60f5649671b2a07312b6e117549"
 
 [[package]]
 name = "js-sys"
@@ -272,17 +326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
-name = "lewton"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be42bea7971f4ba0ea1e215730c29bc1ff9bd2a9c10013912f42a8dcf8d77c0d"
-dependencies = [
- "byteorder",
- "ogg",
- "tinyvec",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,13 +351,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
+name = "maybe-uninit"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memalloc"
@@ -327,6 +367,15 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "memoffset"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "midir"
@@ -347,34 +396,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimp3"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce0cff6a0bfd3f8b6b2350819bbddd63bc65cc45e53888bdd0ff49dde16d2d5"
-dependencies = [
- "minimp3-sys",
- "slice-deque",
-]
-
-[[package]]
-name = "minimp3-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21c73734c69dc95696c9ed8926a2b393171d98b3f5f5935686a26a487ab9b90"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "muse"
 version = "0.0.1-dev"
 dependencies = [
  "anyhow",
  "approx",
+ "cpal",
+ "crossbeam",
  "kurbo",
  "lazy_static",
  "pitch_calc",
- "rodio",
  "thiserror",
 ]
 
@@ -476,15 +507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "ogg"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79f1db9148be9d0e174bb3ac890f6030fcb1ed947267c5a91ee4c91b5a91e15"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -590,20 +612,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
-name = "rodio"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73bbf260262fd5501b7a17d6827e0d25c1127e921eb177150a060faf6e217a70"
-dependencies = [
- "claxon",
- "cpal",
- "hound",
- "lazy_static",
- "lewton",
- "minimp3",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,21 +624,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-
-[[package]]
-name = "slice-deque"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ef6ee280cdefba6d2d0b4b78a84a1c1a3f3a4cec98c2d4231c8bc225de0f25"
-dependencies = [
- "libc",
- "mach",
- "winapi",
-]
 
 [[package]]
 name = "stdweb"
@@ -678,12 +681,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 
 [[package]]
 name = "unicode-xid"

--- a/amuse/src/main.rs
+++ b/amuse/src/main.rs
@@ -154,7 +154,7 @@ impl From<u8> for Controller {
 pub struct TestInstrument {}
 
 impl ToneGenerator for TestInstrument {
-    type Source = Pan;
+    type Source = Amplify;
     fn generate_tone(
         note: Note,
         controls: &mut ControlHandles,
@@ -173,12 +173,14 @@ impl ToneGenerator for TestInstrument {
             .build()?;
 
         let wave = Pan::new(
-            Parameter::Value(1.0),
+            Parameter::Value(0.0),
             Oscillator::<Sine>::new(frequency, envelope_config.as_parameter(controls)),
         );
 
-        //Ok(wave.amplify(note.velocity as f32 / 127.0 * 0.3))
-        Ok(wave)
+        Ok(Amplify::new(
+            Parameter::Value(note.velocity as f32 / 127.0 * 0.4),
+            wave,
+        ))
     }
 }
 

--- a/amuse/src/main.rs
+++ b/amuse/src/main.rs
@@ -154,7 +154,7 @@ impl From<u8> for Controller {
 pub struct TestInstrument {}
 
 impl ToneGenerator for TestInstrument {
-    type Source = rodio::source::Amplify<Pan>;
+    type Source = Pan;
     fn generate_tone(
         note: Note,
         controls: &mut ControlHandles,
@@ -177,7 +177,8 @@ impl ToneGenerator for TestInstrument {
             Oscillator::<Sine>::new(frequency, envelope_config.as_parameter(controls)),
         );
 
-        Ok(wave.amplify(note.velocity as f32 / 127.0 * 0.3))
+        //Ok(wave.amplify(note.velocity as f32 / 127.0 * 0.3))
+        Ok(wave)
     }
 }
 

--- a/muse/Cargo.toml
+++ b/muse/Cargo.toml
@@ -11,12 +11,13 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-rodio = "0.11"
+cpal = "0.11"
 pitch_calc = "0.12"
 anyhow = "1"
 thiserror = "1"
 lazy_static = "1"
 kurbo = "0.6"
+crossbeam = "0.7"
 
 [dev-dependencies]
 approx = "0.3"

--- a/muse/src/amplify.rs
+++ b/muse/src/amplify.rs
@@ -1,0 +1,31 @@
+use crate::{
+    parameter::Parameter,
+    sampler::{Sample, Sampler},
+};
+
+#[derive(Debug)]
+pub struct Amplify {
+    amplify: Parameter,
+    source: Box<dyn Sampler + Send + Sync>,
+}
+
+impl Amplify {
+    pub fn new<T: Sampler + Send + Sync + 'static>(amplify: Parameter, source: T) -> Self {
+        Self {
+            amplify,
+            source: Box::new(source),
+        }
+    }
+}
+
+impl Sampler for Amplify {
+    fn sample(&mut self, sample_rate: u32) -> Option<Sample> {
+        if let Some(sample) = self.source.sample(sample_rate) {
+            if let Some(amplify) = self.amplify.next(sample_rate) {
+                return Some(sample * amplify);
+            }
+        }
+
+        None
+    }
+}

--- a/muse/src/device.rs
+++ b/muse/src/device.rs
@@ -1,0 +1,50 @@
+use crate::{
+    manager::{Manager, ManagerHandle, ManagerMessage, PlayingHandle},
+    sampler::Sampler,
+};
+use cpal::traits::{DeviceTrait, HostTrait};
+use crossbeam::channel::bounded;
+
+#[derive(thiserror::Error, Debug)]
+pub enum HardwareError {
+    #[error("no default output device found")]
+    NoDefaultOutputDevice,
+    #[error("Error getting devices {0}")]
+    DevicesError(#[from] cpal::DevicesError),
+    #[error("Error getting device name {0}")]
+    DeviceNameError(#[from] cpal::DeviceNameError),
+    #[error("Error getting supported formats {0}")]
+    SupportedFormatsError(#[from] cpal::SupportedFormatsError),
+    #[error("Error getting default format {0}")]
+    DefaultFormatError(#[from] cpal::DefaultFormatError),
+}
+
+pub struct Device {
+    manager: ManagerHandle,
+}
+
+impl Device {
+    pub fn default_output() -> Result<Self, anyhow::Error> {
+        let host = cpal::default_host();
+        if let Some(cpal_device) = host.default_output_device() {
+            let format = cpal_device.default_output_format()?;
+            let manager = Manager::open_output_device(host, cpal_device, format)?;
+            Ok(Self { manager })
+        } else {
+            Err(anyhow::Error::from(HardwareError::NoDefaultOutputDevice))
+        }
+    }
+
+    pub fn play<T: Sampler + 'static>(&self, sampler: T) -> Result<PlayingHandle, anyhow::Error> {
+        let (callback, handle) = bounded(1);
+        {
+            let manager = self.manager.read().expect("Error reading manager");
+            manager.sender.send(ManagerMessage::Append {
+                sampler: Box::new(sampler),
+                callback,
+            })?;
+        }
+
+        Ok(handle.recv()?)
+    }
+}

--- a/muse/src/lib.rs
+++ b/muse/src/lib.rs
@@ -1,11 +1,17 @@
+pub mod device;
 pub mod envelope;
 pub mod instrument;
+pub mod manager;
 pub mod note;
 pub mod oscillators;
 pub mod pan;
 pub mod parameter;
+pub mod sampler;
+
+pub use cpal;
 
 pub mod prelude {
-    pub use super::{envelope::*, instrument::*, note::*, oscillators::*, pan::*, parameter::*};
-    pub use rodio::{self, Source};
+    pub use super::{
+        cpal, envelope::*, instrument::*, note::*, oscillators::*, pan::*, parameter::*,
+    };
 }

--- a/muse/src/lib.rs
+++ b/muse/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod amplify;
 pub mod device;
 pub mod envelope;
 pub mod instrument;
@@ -12,6 +13,6 @@ pub use cpal;
 
 pub mod prelude {
     pub use super::{
-        cpal, envelope::*, instrument::*, note::*, oscillators::*, pan::*, parameter::*,
+        amplify::*, cpal, envelope::*, instrument::*, note::*, oscillators::*, pan::*, parameter::*,
     };
 }

--- a/muse/src/manager.rs
+++ b/muse/src/manager.rs
@@ -1,0 +1,207 @@
+use crate::sampler::{Sample, Sampler};
+use cpal::{
+    traits::{EventLoopTrait, HostTrait},
+    Sample as CpalSample,
+};
+use crossbeam::{
+    channel::{unbounded, Receiver, RecvTimeoutError, Sender},
+    sync::ShardedLock,
+};
+use std::{sync::Arc, time::Duration};
+
+pub(crate) enum ManagerMessage {
+    Append {
+        sampler: Box<dyn Sampler>,
+        callback: Sender<PlayingHandle>,
+    },
+}
+
+pub type ManagerHandle = Arc<ShardedLock<Manager>>;
+
+#[derive(Clone, Debug)]
+pub struct PlayingHandle(Arc<u64>);
+
+#[derive(Debug)]
+struct PlayingSound {
+    handle: PlayingHandle,
+    sampler: Box<dyn Sampler>,
+}
+
+#[derive(Debug)]
+pub struct Manager {
+    playing_sounds: Vec<PlayingSound>,
+    last_playing_sound_id: u64,
+    pub(crate) sender: Sender<ManagerMessage>,
+    stream: cpal::StreamId,
+}
+
+impl Manager {
+    pub(crate) fn open_output_device(
+        host: cpal::Host,
+        output_device: cpal::Device,
+        format: cpal::Format,
+    ) -> Result<ManagerHandle, anyhow::Error> {
+        let event_loop = host.event_loop();
+        let output_stream_id = event_loop.build_output_stream(&output_device, &format)?;
+        event_loop.play_stream(output_stream_id.clone())?;
+
+        let (sender, receiver) = unbounded();
+
+        let manager = Arc::new(ShardedLock::new(Manager::new(sender, output_stream_id)));
+
+        let manager_for_thread = manager.clone();
+        std::thread::Builder::new()
+            .name("muse::manager".to_owned())
+            .spawn(move || {
+                ManagerThread::new(manager_for_thread, receiver)
+                    .main()
+                    .unwrap_or_default()
+            })?;
+
+        let manager_for_thread = manager.clone();
+        std::thread::Builder::new()
+            .name("muse::cpal".to_owned())
+            .spawn(move || CpalThread::run(manager_for_thread, event_loop, format))?;
+
+        Ok(manager)
+    }
+
+    fn new(sender: Sender<ManagerMessage>, stream: cpal::StreamId) -> Self {
+        Self {
+            sender,
+            stream,
+            playing_sounds: Vec::new(),
+            last_playing_sound_id: 0,
+        }
+    }
+}
+
+struct ManagerThread {
+    receiver: Receiver<ManagerMessage>,
+    manager: Arc<ShardedLock<Manager>>,
+}
+
+impl ManagerThread {
+    fn new(manager: Arc<ShardedLock<Manager>>, receiver: Receiver<ManagerMessage>) -> Self {
+        Self { manager, receiver }
+    }
+
+    fn main(&mut self) -> Result<(), RecvTimeoutError> {
+        loop {
+            // Check for new messages
+            if let Err(err) = self.handle_incoming_messages() {
+                if let RecvTimeoutError::Timeout = err {
+                    continue;
+                } else {
+                    return Err(err);
+                }
+            }
+
+            // TODO remove sounds that are finished playing
+        }
+    }
+
+    fn handle_incoming_messages(&mut self) -> Result<(), RecvTimeoutError> {
+        match self.receiver.recv_timeout(Duration::from_millis(10)) {
+            Ok(ManagerMessage::Append { sampler, callback }) => {
+                let handle = {
+                    // Scope this write so that sending the handle across the callback doesn't happen while the lock is still held
+                    let mut manager = self
+                        .manager
+                        .write()
+                        .expect("Error locking manager to add sampler");
+                    manager.last_playing_sound_id = manager.last_playing_sound_id.wrapping_add(1);
+
+                    let handle = PlayingHandle(Arc::new(manager.last_playing_sound_id));
+                    manager.playing_sounds.push(PlayingSound {
+                        handle: handle.clone(),
+                        sampler,
+                    });
+                    handle
+                };
+
+                callback.send(handle).unwrap_or_default();
+
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    }
+}
+
+struct CpalThread {}
+
+impl CpalThread {
+    fn run(
+        manager: Arc<ShardedLock<Manager>>,
+        event_loop: cpal::EventLoop,
+        format: cpal::Format,
+    ) -> ! {
+        event_loop.run(move |id, result| {
+            let data = match result {
+                Ok(data) => data,
+                Err(err) => {
+                    eprintln!("an error occurred on stream {:?}: {}", id, err);
+                    return;
+                }
+            };
+
+            match data {
+                cpal::StreamData::Output {
+                    buffer: cpal::UnknownTypeOutputBuffer::U16(buffer),
+                } => {
+                    Self::copy_samples(&manager, buffer, &format);
+                }
+                cpal::StreamData::Output {
+                    buffer: cpal::UnknownTypeOutputBuffer::I16(buffer),
+                } => {
+                    Self::copy_samples(&manager, buffer, &format);
+                }
+                cpal::StreamData::Output {
+                    buffer: cpal::UnknownTypeOutputBuffer::F32(buffer),
+                } => {
+                    Self::copy_samples(&manager, buffer, &format);
+                }
+                _ => (),
+            }
+        });
+    }
+
+    fn next_sample(manager: &ManagerHandle, format: &cpal::Format) -> Sample {
+        let mut manager = manager.write().expect("Error locking manager for sampling");
+        let mut combined_sample = Sample::default();
+        for sample in manager
+            .playing_sounds
+            .iter_mut()
+            .filter_map(|s| s.sampler.sample(format.sample_rate.0))
+        {
+            combined_sample += sample;
+        }
+        combined_sample
+    }
+
+    fn copy_samples<S>(
+        manager: &ManagerHandle,
+        mut buffer: cpal::OutputBuffer<S>,
+        format: &cpal::Format,
+    ) where
+        S: CpalSample,
+    {
+        for sample in buffer.chunks_mut(format.channels as usize) {
+            let generated_sample = Self::next_sample(manager, format);
+
+            match format.channels {
+                1 => {
+                    sample[0] = cpal::Sample::from(
+                        &((generated_sample.left + generated_sample.right) / 2.0),
+                    )
+                }
+                2 => {
+                    sample[0] = cpal::Sample::from(&generated_sample.left);
+                    sample[1] = cpal::Sample::from(&generated_sample.right);
+                }
+                _ => panic!("Unsupported number of channels {}", format.channels),
+            }
+        }
+    }
+}

--- a/muse/src/oscillators/mod.rs
+++ b/muse/src/oscillators/mod.rs
@@ -1,9 +1,6 @@
+use crate::sampler::{Sample, Sampler};
 use lazy_static::lazy_static;
-use rodio::Source;
-use std::{
-    f32::consts::PI,
-    time::{Duration, Instant},
-};
+use std::{f32::consts::PI, time::Instant};
 
 mod sawtooth;
 mod sine;
@@ -23,7 +20,7 @@ lazy_static! {
 pub struct Oscillator<T> {
     frequency: f32,
     amplitude: Parameter,
-    current_sample: usize,
+    current_sample: Option<usize>,
     _of: std::marker::PhantomData<T>,
 }
 
@@ -32,66 +29,52 @@ impl<T> Oscillator<T> {
         Self {
             frequency,
             amplitude,
-            current_sample: Self::initial_sample(),
+            current_sample: None,
             _of: std::marker::PhantomData::default(),
         }
     }
 
-    fn initial_sample() -> usize {
+    fn initial_sample(sample_rate: u32) -> usize {
         let now = Instant::now();
         let subsec = now
             .checked_duration_since(*STARTUP_INSTANT)
             .unwrap_or_default()
             .subsec_nanos() as f32
             / 1_000_000_000.0;
-        let current_sample = subsec * Self::sample_rate() as f32;
+        let current_sample = subsec * sample_rate as f32;
         current_sample as usize
     }
 
-    pub const fn sample_rate() -> u32 {
-        48000
+    fn next_sample(&mut self, sample_rate: u32) -> usize {
+        let new_sample = match self.current_sample {
+            Some(existing) => existing.wrapping_add(1),
+            None => Self::initial_sample(sample_rate),
+        };
+        self.current_sample = Some(new_sample);
+        new_sample
     }
 }
 
-pub trait OscillatorFunction {
+pub trait OscillatorFunction: Send + Sync + std::fmt::Debug {
     fn compute_sample(value: f32) -> f32;
 }
 
-impl<T> Iterator for Oscillator<T>
+impl<T> Sampler for Oscillator<T>
 where
     T: OscillatorFunction,
 {
-    type Item = f32;
-
-    fn next(&mut self) -> Option<f32> {
-        self.current_sample = self.current_sample.wrapping_add(1);
-        let value = self.frequency * 2.0 * std::f32::consts::PI * self.current_sample as f32
-            / Self::sample_rate() as f32;
+    fn sample(&mut self, sample_rate: u32) -> Option<Sample> {
+        let current_sample = self.next_sample(sample_rate) as f32;
+        let value =
+            self.frequency * 2.0 * std::f32::consts::PI * current_sample / sample_rate as f32;
         let value = value % (2.0 * PI);
+        let sample = T::compute_sample(value);
 
         self.amplitude
-            .next(self.sample_rate())
-            .map(|amplification| amplification * T::compute_sample(value))
-    }
-}
-
-impl<T> Source for Oscillator<T>
-where
-    T: OscillatorFunction,
-{
-    fn current_frame_len(&self) -> Option<usize> {
-        None
-    }
-
-    fn channels(&self) -> u16 {
-        1
-    }
-
-    fn sample_rate(&self) -> u32 {
-        Oscillator::<T>::sample_rate()
-    }
-
-    fn total_duration(&self) -> Option<Duration> {
-        None
+            .next(sample_rate)
+            .map(|amplification| Sample {
+                left: amplification * sample / 2.0,
+                right: amplification * sample / 2.0,
+            })
     }
 }

--- a/muse/src/oscillators/sawtooth.rs
+++ b/muse/src/oscillators/sawtooth.rs
@@ -1,6 +1,7 @@
 use super::OscillatorFunction;
 use std::f32::consts::PI;
 
+#[derive(Debug)]
 pub struct Sawtooth {}
 
 impl OscillatorFunction for Sawtooth {

--- a/muse/src/oscillators/sine.rs
+++ b/muse/src/oscillators/sine.rs
@@ -1,5 +1,6 @@
 use super::OscillatorFunction;
 
+#[derive(Debug)]
 pub struct Sine {}
 
 impl OscillatorFunction for Sine {

--- a/muse/src/oscillators/square.rs
+++ b/muse/src/oscillators/square.rs
@@ -1,6 +1,7 @@
 use super::OscillatorFunction;
 use std::f32::consts::PI;
 
+#[derive(Debug)]
 pub struct Square {}
 
 impl OscillatorFunction for Square {

--- a/muse/src/oscillators/triangle.rs
+++ b/muse/src/oscillators/triangle.rs
@@ -1,6 +1,7 @@
 use super::OscillatorFunction;
 use std::f32::consts::PI;
 
+#[derive(Debug)]
 pub struct Triangle {}
 
 impl OscillatorFunction for Triangle {

--- a/muse/src/pan.rs
+++ b/muse/src/pan.rs
@@ -1,79 +1,40 @@
-use crate::parameter::Parameter;
-use rodio::Source;
-use std::time::Duration;
+use crate::{
+    parameter::Parameter,
+    sampler::{Sample, Sampler},
+};
 
+#[derive(Debug)]
 pub struct Pan {
     pan: Parameter,
-    source: Box<dyn Source<Item = f32> + Send + Sync>,
-    current_sample: Option<PanFrame>,
+    source: Box<dyn Sampler + Send + Sync>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct PanFrame {
-    sample: f32,
+    sample: Sample,
     pan: f32,
 }
 
-impl PanFrame {
-    pub fn value(&self) -> f32 {
-        self.sample * self.pan
-    }
-
-    pub fn second_channel_value(&self) -> f32 {
-        self.sample * (1.0 - self.pan)
-    }
-}
-
 impl Pan {
-    pub fn new<T: Source<Item = f32> + Send + Sync + 'static>(
-        parameter: Parameter,
-        source: T,
-    ) -> Self {
+    pub fn new<T: Sampler + Send + Sync + 'static>(parameter: Parameter, source: T) -> Self {
         Self {
             pan: parameter,
             source: Box::new(source),
-            current_sample: None,
-        }
-    }
-
-    fn next_frame(&mut self) -> Option<PanFrame> {
-        self.source.next().map(|sample| PanFrame {
-            sample,
-            pan: self.pan.next(self.sample_rate()).unwrap(),
-        })
-    }
-}
-
-impl Iterator for Pan {
-    type Item = f32;
-    fn next(&mut self) -> Option<Self::Item> {
-        // 2 channel panning, first access stores the value and returns it, the second access consumes the current sample
-        if let Some(frame) = self.current_sample {
-            self.current_sample = None;
-            Some(frame.second_channel_value())
-        } else if let Some(frame) = self.next_frame() {
-            self.current_sample = Some(frame);
-            Some(frame.value())
-        } else {
-            None
         }
     }
 }
 
-impl Source for Pan {
-    fn current_frame_len(&self) -> Option<usize> {
-        self.source.current_frame_len()
-    }
+impl Sampler for Pan {
+    fn sample(&mut self, sample_rate: u32) -> Option<Sample> {
+        if let Some(sample) = self.source.sample(sample_rate) {
+            if let Some(pan) = self.pan.next(sample_rate) {
+                return Some(Sample {
+                    left: sample.left * (1. - pan),
+                    right: sample.right * pan,
+                });
+            }
+        }
 
-    fn channels(&self) -> u16 {
-        2
-    }
-
-    fn sample_rate(&self) -> u32 {
-        self.source.sample_rate()
-    }
-
-    fn total_duration(&self) -> Option<Duration> {
-        self.source.total_duration()
+        None
     }
 }

--- a/muse/src/sampler.rs
+++ b/muse/src/sampler.rs
@@ -25,3 +25,21 @@ impl std::ops::AddAssign<Sample> for Sample {
         self.right += rhs.right;
     }
 }
+
+impl std::ops::Mul<f32> for Sample {
+    type Output = Self;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        Self {
+            left: self.left * rhs,
+            right: self.right * rhs,
+        }
+    }
+}
+
+impl std::ops::MulAssign<f32> for Sample {
+    fn mul_assign(&mut self, rhs: f32) {
+        self.left *= rhs;
+        self.right *= rhs;
+    }
+}

--- a/muse/src/sampler.rs
+++ b/muse/src/sampler.rs
@@ -1,0 +1,27 @@
+#[derive(Clone, Debug, Default)]
+pub struct Sample {
+    pub left: f32,
+    pub right: f32,
+}
+
+pub trait Sampler: Send + Sync + std::fmt::Debug {
+    fn sample(&mut self, sample_rate: u32) -> Option<Sample>;
+}
+
+impl std::ops::Add<Sample> for Sample {
+    type Output = Self;
+
+    fn add(self, rhs: Sample) -> Self::Output {
+        Self {
+            left: self.left + rhs.left,
+            right: self.right + rhs.right,
+        }
+    }
+}
+
+impl std::ops::AddAssign<Sample> for Sample {
+    fn add_assign(&mut self, rhs: Sample) {
+        self.left += rhs.left;
+        self.right += rhs.right;
+    }
+}


### PR DESCRIPTION
This morning I [implemented pan](https://github.com/khonsulabs/muse/commit/ad0199eb9782c02f0432b3cae34d6888288b61ef) in as straightforward a way as possible, but that commit was a result of several hours of labor of trying various dances to get Rodio to always treat my first sample as Left and my second sample as Right. Unfortunately, I could not get it to work reliably.

I pushed this code and switched to my MacBook Pro, and I ran into a separate issue relating to my AirPods. I was having a tough time telling from the built-in speakers, and once I hooked up my AIrPods, rodio was crashing because of getting a null value back from the name of some source. I googled and found issues [like this](https://github.com/RustAudio/rodio/issues/252) which doesn't exactly confirm that the issue was not in my code, but I was getting frustrated.

I ended up changing a lot about how samples work in Muse as part of this, so I can't say for certain that my old code wasn't buggy, but in cpal I've had no issues with my stereo audio.

There's a lot of work left to fully replace rodio, such as implementing the ability to play sounds from files, but the focus right now is on synthesis not sampling, so I am moving forward with this.